### PR TITLE
Protection against buffer overflow +more

### DIFF
--- a/client/headers/settings.h
+++ b/client/headers/settings.h
@@ -37,16 +37,15 @@
  * To change the Server change the HOST_NAME & HOST_CERT to match your servers
  */
 
-
+/*
 #define HOST_NAME "52.14.103.245" //Default Server IP
 #define HOST_PORT "5050" //SSC Port
 #define HOST_CERT "default/public.pem" //Default Server Certificate (Change path if your hosting your own server)
+*/
 
-/*
 #define HOST_NAME "127.0.0.1"
 #define HOST_PORT "5050"
 #define HOST_CERT "public.pem"
-*/
 
 #define PUB_KEY "rsapublickey.pem" //Public Key location (Will be generated if not found)
 #define PRIV_KEY "rsaprivatekey.pem" //Private Key location (Will be generated if not found)

--- a/client/headers/settings.h
+++ b/client/headers/settings.h
@@ -37,16 +37,16 @@
  * To change the Server change the HOST_NAME & HOST_CERT to match your servers
  */
 
-/*
+
 #define HOST_NAME "52.14.103.245" //Default Server IP
 #define HOST_PORT "5050" //SSC Port
 #define HOST_CERT "default/public.pem" //Default Server Certificate (Change path if your hosting your own server)
-*/
 
+/*
 #define HOST_NAME "127.0.0.1"
 #define HOST_PORT "5050"
 #define HOST_CERT "public.pem"
-
+*/
 #define PUB_KEY "rsapublickey.pem" //Public Key location (Will be generated if not found)
 #define PRIV_KEY "rsaprivatekey.pem" //Private Key location (Will be generated if not found)
 #define KEYSIZE 2048 //keysize used to generate key (has to be 1024,2048,4096,or 8192)

--- a/server/headers/base64.c
+++ b/server/headers/base64.c
@@ -34,7 +34,7 @@ unsigned char * mitbase64_encode(const unsigned char *src, size_t len,
 	olen++; /* nul termination */
 	if (olen < len)
 		return NULL; /* integer overflow */
-	out = malloc(olen); if (out == NULL) return NULL;
+	out = cmalloc(olen); if (out == NULL) return NULL;
 
 	end = src + len;
 	in = src;
@@ -101,7 +101,7 @@ unsigned char * mitbase64_decode(const unsigned char *src, size_t len,
 		return NULL;
 
 	olen = count / 4 * 3;
-	pos = out = malloc(olen);
+	pos = out = cmalloc(olen);
 	if (out == NULL)
 		return NULL;
 
@@ -127,7 +127,7 @@ unsigned char * mitbase64_decode(const unsigned char *src, size_t len,
 					pos -= 2;
 				else {
 					/* Invalid padding */
-					free(out);
+					cfree(out);
 					return NULL;
 				}
 				break;

--- a/server/headers/base64.h
+++ b/server/headers/base64.h
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "settings.h"
 /*
 * Names changed from base64_encode & base64_decode to mitbase64_encode & mitbase64_decode because conflict with mysql client library function
 */

--- a/server/headers/hashing.c
+++ b/server/headers/hashing.c
@@ -20,7 +20,7 @@
 #include "hashing.h"
 
 byte* memncat(byte* first,size_t firstl,byte* second,size_t secondl){ //concatenates two blocks of memory 
-	byte* finalbuffer = malloc(firstl+secondl);
+	byte* finalbuffer = cmalloc(firstl+secondl);
 	byte* writepointer = finalbuffer;
 	memcpy(writepointer,first,firstl);
 	writepointer+=firstl;
@@ -44,12 +44,12 @@ SSCS_HASH* SSCS_createhash(byte* data,size_t datal){
 	size_t b64hashl = 0;
 	byte* b64hash = mitbase64_encode(hash,SHA512_DIGEST_LENGTH,&b64hashl);
 
-	SSCS_HASH* retstruct = malloc(sizeof(SSCS_HASH));
+	SSCS_HASH* retstruct = cmalloc(sizeof(SSCS_HASH));
 	retstruct->hash = b64hash;
 	retstruct->hashl = b64hashl;
 	retstruct->salt = b64salt;
 	retstruct->saltl = b64saltl;
-	free(salt_and_data);
+	cfree(salt_and_data);
 	return retstruct;
 }
 
@@ -65,21 +65,21 @@ int SSCS_comparehash(byte* data,size_t datal,SSCS_HASH* originalhash){
 	size_t b64data_hash_len = 0;
 	byte* b64data_hash = mitbase64_encode(data_hash,SHA512_DIGEST_LENGTH,&b64data_hash_len);
 	if(b64data_hash_len != hashl){
-		free(salt_and_data);
-		free(b64data_hash);
+		cfree(salt_and_data);
+		cfree(b64data_hash);
 		return SSCS_HASH_INVALID;
 	}
 	int result = memcmp(hash,b64data_hash,SHA512_DIGEST_LENGTH);
-	free(salt_and_data);
-	free(b64data_hash);
+	cfree(salt_and_data);
+	cfree(b64data_hash);
 	if(result==0)return SSCS_HASH_VALID;
 	return SSCS_HASH_INVALID;
 }
 
 void SSCS_freehash(SSCS_HASH** hash){
-	free(((*hash)->hash));
-	free(((*hash)->salt));
-	free((*hash));
+	cfree(((*hash)->hash));
+	cfree(((*hash)->salt));
+	cfree((*hash));
 	*hash = NULL;
 }
 

--- a/server/headers/hashing.h
+++ b/server/headers/hashing.h
@@ -26,6 +26,7 @@
 #include <openssl/sha.h>
 #include <openssl/rand.h>
 #include "base64.h"
+#include "settings.h"
 
 #define SSCS_HASH_VALID 1
 #define SSCS_HASH_INVALID 2

--- a/server/headers/protected_malloc.c
+++ b/server/headers/protected_malloc.c
@@ -1,0 +1,242 @@
+
+/*
+ *  <SimpleSecureChat Client/Server - E2E encrypted messaging application written in C>
+ *  Copyright (C) 2017-2018 The SimpleSecureChat Authors. <kping0> 
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "protected_malloc.h"
+
+/*
+ * Check address for padding errors
+ */
+void sscs_chkaddr(void* ptr,const char* file,int line){
+	void* orig = ptr-21; //get original allocated buffer
+	byte* readpointer = (byte*)orig;	
+	int chv = *(int*)readpointer; readpointer+=4;
+	if(chv != SSCS_HEAP_MAGIC){
+		fprintf(stderr,"[ERROR] sscs_chkaddr() header checksum error - Called from %s - line %d\n",file,line);
+		fprintf(stderr,"[SECURITY_WARNING] Heap Overflow at address %p likely,exiting \n",orig);
+		exit(1);
+	}
+	byte* rngbytes = readpointer; readpointer += 8;
+	size_t bufsize = *(size_t*)readpointer; readpointer += 8;
+	if(bufsize <= 0){
+		fprintf(stderr,"[ERROR] sscs_chkaddr() bufsize <= 0 - Called from %s - line %d\n",file,line);
+		fprintf(stderr,"[SECURITY_WARNING] Heap Overflow at address %p likely,exiting \n",orig);
+		exit(1);
+	}
+	if(*readpointer != 0x0){
+		fprintf(stderr,"[ERROR] sscs_chkaddr() incorrect padding (!0x0) - Called from %s - line %d\n",file,line);
+		fprintf(stderr,"[SECURITY_WARNING] Heap Overflow at address %p likely,exiting \n",orig);
+		exit(1);
+	}	
+	readpointer++;	
+	readpointer+=bufsize;	
+	if(*readpointer != 0x0){
+		fprintf(stderr,"[ERROR] sscs_chkaddr() (tail) incorrect padding - Called from %s - line %d\n",file,line);
+		fprintf(stderr,"[SECURITY_WARNING] Heap Overflow at address %p likely,exiting \n",orig);
+		exit(1);
+	}
+	readpointer++;
+	if(memcmp(rngbytes,readpointer,8)){
+		fprintf(stderr,"[ERROR] sscs_chkaddr() (tail) header-tail rng doesnt match - Called from %s - line %d\n",file,line);	
+		fprintf(stderr,"[SECURITY_WARNING] Heap Overflow at address %p likely, exiting\n",orig);
+		exit(1);
+	}
+	readpointer+=8;
+	chv = *(int*)readpointer;
+	if(chv != SSCS_HEAP_MAGIC){
+		fprintf(stderr,"[ERROR] sscs_chkaddr() tail checksum error - Called from %s - line %d\n",file,line);
+		fprintf(stderr,"[SECURITY_WARNING] Heap Overflow at address %p likely,exiting \n",orig);
+		exit(1);	
+	}
+	return;	
+}
+
+size_t sscs_heap_object_size(void* ptr,const char* file,int line){
+	sscs_chkaddr(ptr,file,line); //check address for padding issues 
+	return *((size_t*)(ptr-9)); //return sizeof usable buffer
+}
+
+void sscs_ignore_result(long long int unused){ //used to suppress write() error
+	(void)unused;
+}
+/*
+ * Signal handler to receive SIGSEGV (if guard page is accessed)
+ */
+void sscs_cmalloc_sig_handler(int signum,siginfo_t *info,void* context){
+	(void)context;
+	(void)signum;
+	char preamble[] = "[ERROR] Received SIGSEGV:";
+	char msg[] = "Address not mapped\n";
+	char msg2[] = "Access Error (to guard page?) -> Heap Overflow attempt possible\n";
+	sscs_ignore_result(write(STDERR_FILENO,preamble,25));
+	switch(info->si_code){
+		case SEGV_MAPERR:
+			sscs_ignore_result(write(STDERR_FILENO,msg,21));
+			break;
+		case SEGV_ACCERR:
+			sscs_ignore_result(write(STDERR_FILENO,msg2,65));
+			break;
+		default:
+			sscs_ignore_result(write(STDERR_FILENO,"unknown error\n",20));
+			break;
+	}
+	fflush(stderr);
+	exit(EXIT_FAILURE);
+}
+
+void sscs_cmalloc_init(void){
+	srand((unsigned int)time(NULL));
+	signal(SIGSEGV,SIG_DFL);
+	struct sigaction sa;
+	sa.sa_flags = SA_SIGINFO;
+	sa.sa_sigaction = sscs_cmalloc_sig_handler;
+	sigemptyset(&sa.sa_mask);
+	sigaction(SIGSEGV,&sa,NULL);
+	return;
+}
+
+unsigned char *gen_rdm_bytestream (size_t num_bytes){  //generate semi-random bytestream
+  unsigned char *stream = malloc(num_bytes);
+  size_t i;
+  for (i = 0; i < num_bytes; i++){
+    stream[i] = rand ();
+  }
+  return stream;
+}
+
+/*
+ * Allocate Buffer 
+ */
+void* sscs_cmalloc(size_t size,const char* file, int line){
+#ifdef DEBUG
+	fprintf(stdout,"[DEBUG] Called sscs_cmalloc() (Called from %s-%d)\n",file,line);
+#endif
+	size_t origsize = size;
+/*
+ * Calculate size to allocate (must be a multiple of PAGESIZE)
+ */ 
+	size += 40; //add 40Bytes for Padding
+	size_t alloc_len = size + PAGESIZE - (size % PAGESIZE) + PAGESIZE; //get next multiple of pagesize that fits size&metadata + guardpage length
+	char* buf = aligned_alloc(PAGESIZE,alloc_len);
+	if(!buf){
+		fprintf(stderr,"[ERROR] could not allocate aligned memory (called from %s line %d)\n",file,line);
+		return NULL;
+	}
+	memset(buf,0,alloc_len);
+/*
+ * Add a Guard Page to the end of the allocated buffer
+ * Note that this has a HUGE memory overhead especially for small buffers -> cmalloc(10) -> ~8192B allocated 
+ */
+	if(mprotect(buf+(alloc_len-PAGESIZE),PAGESIZE,PROT_NONE) != 0){ //create a 4KB guard page 
+		fprintf(stderr,"[ERROR] Could not add guard page (called from %s line %d): ",file,line);
+		switch(errno){
+			case EACCES:
+				fprintf(stderr,"EACCES (Memory Access Error)\n");
+				free(buf);
+				return NULL;
+				break;
+			case EINVAL:
+				fprintf(stderr,"EINVAL ( (internal)buf ptr !valid OR not correctly aligned)\n");			
+				free(buf);
+				return NULL;
+				break;
+			case ENOMEM:
+				fprintf(stderr,"ENOMEM (Kernel struct allocation error OR invalid address range)\n");
+				free(buf);
+				return NULL;
+				break;
+			case EFAULT:
+				fprintf(stderr,"EFAULT (Memory cannot be accessed)\n");
+				free(buf);
+				return NULL;
+				break;
+			default:
+				fprintf(stderr,"Unknown Error\n");
+				free(buf);
+				return NULL;
+				break;
+		}
+	}
+/*
+ * Write Metadata to the buffer
+ */
+	void* writepointer = buf;
+	*(int*)writepointer = SSCS_HEAP_MAGIC; writepointer += 4; //add SSCS_HEAP_MAGIC  
+	size_t* checkvar = (size_t*)gen_rdm_bytestream(8); //add secret magic
+	*(size_t*)writepointer = *checkvar; writepointer += 8;
+	*(size_t*)writepointer = origsize; writepointer += 8; //add size 
+	*(char*)writepointer = 0x0; writepointer++; //padding
+	void* retptr = writepointer; writepointer+=origsize; //actual buffer
+	*(char*)writepointer = 0x0; writepointer++; //padding	
+	*(size_t*)writepointer = *checkvar; writepointer += 8; 
+	*(int*)writepointer = SSCS_HEAP_MAGIC; writepointer += 4; //add SSCS_HEAP_MAGIC
+	free(checkvar);	
+	return retptr;
+}
+
+void sscs_cfree(void* ptr,const char* file,int line){
+#ifdef DEBUG
+	fprintf(stdout,"[DEBUG] Called sscs_cfree() (Called from %s-%d)\n",file,line);
+#endif
+	if(ptr == NULL){
+	#ifdef DEBUG
+		fprintf(stdout,"[DEBUG] ptr passed is NULL\n");
+	#endif
+		return;
+	}
+	void* orig = ptr-21; //go back to original metasize buffer
+	sscs_chkaddr(ptr,__FILE__,__LINE__);
+
+/*
+ * We need to calculate the size of the original buffer the way we allocated it so we can reverse the 
+ * guard page to avoid some nasty bugs
+ */
+	size_t size = sscs_heap_object_size(ptr,__FILE__,__LINE__);
+	size += 40;
+	size_t alloc_len = size + PAGESIZE - (size % PAGESIZE) + PAGESIZE; //calculate original alloc_len
+/*
+ * Change the permissions on the page back to Read + Write
+ */
+	if(mprotect(orig+(alloc_len-PAGESIZE),PAGESIZE,PROT_READ | PROT_WRITE) != 0){ 
+		fprintf(stderr,"[ERROR] Could not undo guardpage (called from %s line %d): ",file,line);
+		switch(errno){
+			case EACCES:
+				fprintf(stderr,"EACCES (Memory Access Error)\n");
+				return;
+				break;
+			case EINVAL:
+				fprintf(stderr,"EINVAL ( (internal)buf ptr !valid OR not correctly aligned)\n");			
+				return;
+				break;
+			case ENOMEM:
+				fprintf(stderr,"ENOMEM (Kernel struct allocation error OR invalid address range)\n");
+				return;
+				break;
+			case EFAULT:
+				fprintf(stderr,"EFAULT (Memory cannot be accessed)\n");
+				return; 
+				break;
+			default:
+				fprintf(stderr,"Unknown Error\n");
+				return;
+				break;
+		}
+	}
+	free(orig); //free buffer 
+	return;	
+}

--- a/server/headers/protected_malloc.h
+++ b/server/headers/protected_malloc.h
@@ -1,0 +1,75 @@
+
+/*
+ *  <SimpleSecureChat Client/Server - E2E encrypted messaging application written in C>
+ *  Copyright (C) 2017-2018 The SimpleSecureChat Authors. <kping0> 
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+/*
+ *  Memory Layout for structures on heap allocated by these functions
+ *
+ * -------------------------------------------------------------------------------------------------
+ * | MAGIC | CHKVAR | SIZEOF_BUFFER | 0x0 | USABLE_BUFFER | 0x0 | CHKVAR | MAGIC | ... | GUARDPAGE |
+ * -------------------------------------------------------------------------------------------------
+ * |  4B   |   8B   |      8B       |  1B | 	VAR       | 1B  |   8B   |  4B   | VAR |   4096B   | 
+ * -------------------------------------------------------------------------------------------------
+ * 
+ */
+
+#ifndef SSCS_PROTECTED_MEMALLOC
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <sys/mman.h>
+#include <limits.h>
+#include <errno.h>
+#include <unistd.h>
+#include <time.h>
+#include "settings.h"
+
+
+#ifndef PAGESIZE /* Usually defined in limits.h */
+#define PAGESIZE 4096
+#endif 
+
+#define SSCS_HEAP_MAGIC 0x73736373 /* MAGIC */
+
+typedef unsigned char byte;
+
+#ifdef SSCS_CUSTOM_MALLOC
+
+/* Macros for functions */
+#define cmalloc(size) sscs_cmalloc(size,__FILE__,__LINE__) //call cmalloc(size)
+#define cfree(ptr) sscs_cfree(ptr,__FILE__,__LINE__) //call cfree(ptr)
+#define chkaddr(ptr) sscs_chkaddr(ptr,__FILE__,__LINE__) //call chkaddr(ptr)
+#define cmalloc_init() sscs_cmalloc_init() //call cmalloc_init()
+#define objsize(ptr) sscs_heap_object_size(ptr,__FILE__,__LINE__) //call objsize(ptr)
+
+
+void sscs_cmalloc_init(void); //call once to init rng 
+
+void sscs_cfree(void* ptr,const char* file,int line); //free for sscs_cmalloc  
+	
+void sscs_chkaddr(void* ptr,const char* file,int line); //check address for overflows and padding issues & errors
+
+void* sscs_cmalloc(size_t size,const char* file,int line); //malloc wrapper with error checking
+
+size_t sscs_heap_object_size(void* ptr,const char* file,int line);
+
+#endif /* SSCS_CUSTOM_MALLOC */
+#endif /* SSCS_PROTECTED_MEMALLOC */

--- a/server/headers/serialization.c
+++ b/server/headers/serialization.c
@@ -6,6 +6,8 @@
 
 #include "base64.h" 
 #include "serialization.h" 
+#include "settings.h"
+
 /*
  * SimpleSecureChat Serialization Library. Made with Security in mind.
 */
@@ -28,13 +30,13 @@ byte* memseq(byte* buf,size_t buf_size,byte* byteseq,size_t byteseq_len){
 	return NULL;
 }
 sscso *SSCS_object(void){
-	sscso* obj = calloc(1,sizeof(struct SSCS_struct));		
+	sscso* obj = cmalloc(sizeof(struct SSCS_struct));		
 	obj->buf_ptr = NULL; 
 	obj->allocated = 0;
 	return obj;
 }
 sscsl *SSCS_list(void){
-	sscsl* list = calloc(1,sizeof(struct SSCS_list));
+	sscsl* list = cmalloc(sizeof(struct SSCS_list));
 	list->buf_ptr = NULL;
 	list->allocated = 0;
 	list->items = 0;
@@ -43,9 +45,9 @@ sscsl *SSCS_list(void){
 }
 sscsl *SSCS_list_open(byte* buf){
 	size_t len = strlen((const char*)buf);
-	void* buf_ptr = calloc(1,len);
+	void* buf_ptr = cmalloc(len);
 	memcpy(buf_ptr,buf,len);
-	sscsl *list = calloc(1,sizeof(struct SSCS_list));
+	sscsl *list = cmalloc(sizeof(struct SSCS_list));
 	list->buf_ptr = buf_ptr;
 	list->allocated = len;
 	return list;
@@ -53,9 +55,9 @@ sscsl *SSCS_list_open(byte* buf){
 
 sscso *SSCS_open(byte* buf){
 	size_t len = strlen((const char*)buf);
-	void* buf_ptr = calloc(1,len);
+	void* buf_ptr = cmalloc(len);
 	memcpy(buf_ptr,buf,len);
-	sscso* obj = calloc(1,sizeof(struct SSCS_struct));
+	sscso* obj = cmalloc(sizeof(struct SSCS_struct));
 	obj->buf_ptr = buf_ptr;
 	obj->allocated = len;
 	return obj;
@@ -73,7 +75,7 @@ int SSCS_list_add_data(sscsl* list,byte* data,size_t size){
 	sprintf(label,"%zd:\"",old_buf_items+1);
 	int label_len = strlen((const char*)label);
 	size_t final_intermediate_len = b64datalen+label_len+2;
-	byte* intermediatebuf = calloc(1,final_intermediate_len);
+	byte* intermediatebuf = cmalloc(final_intermediate_len);
 	memset(intermediatebuf,0,final_intermediate_len);
 	byte* ibufwloc = intermediatebuf; //ibufwloc is a pointer to the next area to write to
 	int i = 0;
@@ -88,12 +90,12 @@ int SSCS_list_add_data(sscsl* list,byte* data,size_t size){
 	ibufwloc++;
 	*ibufwloc = ';';
 	ibufwloc++;
-	free(b64data);	
+	cfree(b64data);	
 	size_t new_buf_size = (old_buf_size + final_intermediate_len);
-	void *new_buf_ptr = calloc(1,new_buf_size);
+	void *new_buf_ptr = cmalloc(new_buf_size);
 	memset(new_buf_ptr,0,new_buf_size);
 	if(old_buf_ptr != NULL)memcpy(new_buf_ptr,old_buf_ptr,old_buf_size);
-	free(old_buf_ptr);
+	cfree(old_buf_ptr);
 	old_buf_ptr = NULL;
 	i = 0;
 	byte* base_ptr = new_buf_ptr + old_buf_size ;	
@@ -105,7 +107,7 @@ int SSCS_list_add_data(sscsl* list,byte* data,size_t size){
 	list->allocated = new_buf_size;
 	list->buf_ptr = new_buf_ptr;
 	list->items = old_buf_items+1;
-	free(intermediatebuf);
+	cfree(intermediatebuf);
 	return 0;
 }
 int SSCS_object_add_data(sscso* obj,char* label,byte* data,size_t size){
@@ -114,7 +116,7 @@ int SSCS_object_add_data(sscso* obj,char* label,byte* data,size_t size){
 	size_t old_buf_size = obj->allocated;	
 	int label_len = (int)strlen((const char*)label);
 	int modlabel_len = label_len+2;
-	char* modlabel = calloc(1,modlabel_len+1); //+1 for the NUL 
+	char* modlabel = cmalloc(modlabel_len+1); //+1 for the NUL 
 	sprintf(modlabel,"%s:\"",label);
 	size_t encoded_size;
 	if(old_buf_ptr != NULL){
@@ -128,7 +130,7 @@ int SSCS_object_add_data(sscso* obj,char* label,byte* data,size_t size){
 	byte* b64data = mitbase64_encode(data,size,&encoded_size);
 	int b64datalen = encoded_size;
 	size_t final_intermediate_len = b64datalen+modlabel_len+2; //+2 for the ' "; ' at the end
-	byte* intermediatebuf = calloc(1,final_intermediate_len);
+	byte* intermediatebuf = cmalloc(final_intermediate_len);
 	byte* ibufwloc = intermediatebuf; //ibufwloc is a pointer to the next area to write to
 	size_t i = 0;
 	while(i < strlen(modlabel)){
@@ -142,12 +144,12 @@ int SSCS_object_add_data(sscso* obj,char* label,byte* data,size_t size){
 	ibufwloc++;
 	*ibufwloc = ';';
 	ibufwloc++;
-	free(b64data);	
+	cfree(b64data);	
 	size_t new_buf_size = (old_buf_size + final_intermediate_len);
-	void *new_buf_ptr = calloc(1,new_buf_size);
+	void *new_buf_ptr = cmalloc(new_buf_size);
 	memset(new_buf_ptr,0,new_buf_size);
 	if(old_buf_ptr != NULL)memcpy(new_buf_ptr,old_buf_ptr,old_buf_size);
-	free(old_buf_ptr);
+	cfree(old_buf_ptr);
 	old_buf_ptr = NULL;
 	i = 0;
 	byte* base_ptr = new_buf_ptr + old_buf_size ;	
@@ -158,8 +160,8 @@ int SSCS_object_add_data(sscso* obj,char* label,byte* data,size_t size){
 	}
 	obj->allocated = new_buf_size;
 	obj->buf_ptr = new_buf_ptr;
-	free(intermediatebuf);
-	free(modlabel);
+	cfree(intermediatebuf);
+	cfree(modlabel);
 	return 0;
 }
 sscsd* SSCS_object_data(sscso* obj,char* label){
@@ -178,30 +180,30 @@ sscsd* SSCS_object_data(sscso* obj,char* label){
 		i++;	
 	}
 	double b64encoded_len = i; 
-	byte* b64buffer = calloc(1,b64encoded_len+1); 
+	byte* b64buffer = cmalloc(b64encoded_len+1); 
 	i = 0;
 	/* Run loop again to read encoded string */
 	while(readpointer[i] != '"' && readpointer[i+1] != ';'){ //Get base64encoded data 
 		if(!((size_t)((readpointer+i) - buf_ptr) < allocated) || b64encoded_len < i){
 			//puts("Outsize of memory bounds");
-			free(b64buffer);
+			cfree(b64buffer);
 			return NULL;
 		}
 		*(b64buffer+i) = *(readpointer+i);	
 		i++;
 	}
 	size_t len; 
-	sscsd* final = calloc(1,sizeof(sscsd));
+	sscsd* final = cmalloc(sizeof(sscsd));
 	final->data = mitbase64_decode((const unsigned char*)b64buffer,b64encoded_len,&len); //NOTE THAT THIS IS A POINTER (if an integer was serialized an (int*) )
 	final->len = len;
-	free(b64buffer);
+	cfree(b64buffer);
 	return final;
 }
 sscsd* SSCS_list_data(sscsl* list,unsigned int index){ //Auto incriments after every run.
 	if(index > 4096)return NULL; //support a max of 4096 items
 	byte* buf_ptr = list->buf_ptr;
 	size_t allocated = list->allocated;
-	char* label = calloc(1,30);
+	char* label = cmalloc(30);
 	sprintf(label,"%d:\"",index);
 	size_t label_len = strlen((const char*)label);
 	int i = 0;
@@ -221,28 +223,28 @@ sscsd* SSCS_list_data(sscsl* list,unsigned int index){ //Auto incriments after e
 		i++;	
 	}
 	double b64encoded_len = i; 
-	byte* b64buffer = calloc(1,b64encoded_len+1); 
+	byte* b64buffer = cmalloc(b64encoded_len+1); 
 	i = 0;
 	/* Run loop again to read encoded string */
 	while(readpointer[i] != '"' && readpointer[i+1] != ';'){ //Get base64encoded data 
 		if(!((size_t)((readpointer+i) - buf_ptr) < allocated) || b64encoded_len < i){
 			//puts("Outsize of memory bounds");
-			free(b64buffer);
+			cfree(b64buffer);
 			return NULL;
 		}
 		*(b64buffer+i) = *(readpointer+i);	
 		i++;
 	}
 	size_t len; 
-	sscsd* final = calloc(1,sizeof(sscsd));
+	sscsd* final = cmalloc(sizeof(sscsd));
 	final->data = mitbase64_decode((const unsigned char*)b64buffer,b64encoded_len,&len); //NOTE THAT THIS IS A POINTER (if an integer was serialized an (int*) )
 	final->len = len;
-	free(b64buffer);
-	free(label);
+	cfree(b64buffer);
+	cfree(label);
 	return final;
 }
 char* SSCS_object_encoded(sscso* obj){ //Get string to send over socket
-	char* retptr = calloc(1,obj->allocated+2);
+	char* retptr = cmalloc(obj->allocated+2);
 	memcpy(retptr,obj->buf_ptr,obj->allocated);
 	*(retptr+obj->allocated+1) = '\0';	
 	return retptr;
@@ -252,7 +254,7 @@ size_t SSCS_object_encoded_size(sscso* obj){ //Get size of string(often needs to
 	return obj->allocated;	
 } 
 char* SSCS_list_encoded(sscsl* list){
-	char* retptr = calloc(1,list->allocated+1);
+	char* retptr = cmalloc(list->allocated+1);
 	memcpy(retptr,list->buf_ptr,list->allocated);
 	*(retptr+list->allocated) = '\0';
 	return retptr;
@@ -270,27 +272,27 @@ size_t SSCS_data_get_size(sscsd* data){
 }
 /* UNUSED because all functions allocated a new sscso object and dont reuse 
 void SSCS_free(sscso* obj){ //Frees current buffer associated with sscso obj (Object Can be Reused)
-	free(obj->buf_ptr);
+	cfree(obj->buf_ptr);
 	obj->buf_ptr = NULL;
 	obj->allocated = 0;
 }
 */
 
 void SSCS_release(sscso** obj){ //Frees the current buffer AND the structure holding the address to the buffer; (Object Cant be Reused)
-	free(((*obj)->buf_ptr));
-	free(*obj);
+	cfree(((*obj)->buf_ptr));
+	cfree(*obj);
 	*obj = NULL;
 }
 void SSCS_data_release(sscsd** data){ //Frees the data buffer AND the structure holding the address and the length
 	if(*data == NULL)return;
-	free(((*data)->data));
-	free(*data);
+	cfree(((*data)->data));
+	cfree(*data);
 	*data = NULL;	
 }
 void SSCS_list_release(sscsl** list){
 	if(*list == NULL)return;
-	free(((*list)->buf_ptr));
-	free(*list);
+	if((*list)->buf_ptr != NULL)cfree(((*list)->buf_ptr));
+	cfree(*list);
 	*list = NULL;
 }
 /*
@@ -323,7 +325,7 @@ double SSCS_object_double(sscso* obj,char* label){
 unsigned char* SSCS_object_string(sscso* obj,char* label){
 	sscsd* data = SSCS_object_data(obj,label);
 	if(data == NULL)return NULL;
-	unsigned char* ret_ptr = calloc(1,data->len+2);
+	unsigned char* ret_ptr = cmalloc(data->len+2);
 	memcpy(ret_ptr,data->data,data->len);
 	*(ret_ptr+data->len + 1) = '\0';
 	SSCS_data_release(&data);

--- a/server/headers/serialization.h
+++ b/server/headers/serialization.h
@@ -1,6 +1,8 @@
 #ifndef SSCS_SERIALIZATION
 #define SSCS_SERIALIZATION
 
+#include "settings.h"
+
 struct SSCS_struct{ //SSCS_object
 	void* buf_ptr; //Pointer to current buffer
 	size_t allocated; //Size of current buffer (allocated amount)

--- a/server/headers/settings.h
+++ b/server/headers/settings.h
@@ -42,4 +42,23 @@
 #define SSCS_KEYFILE "key.pem" //Key file
 #define SSCS_KEYFILE_PW "test" //key file password
 
+/* 
+ * Use Custom Malloc or system specific malloc & free
+ * NOTE: The custom malloc has a HUGE ~4KB overhead per allocation due to a Guard Page protecting 
+ * against Heap Overflows
+ *
+ * Better-performance -> Use Default Malloc 
+ * Security -> Use Custom Malloc
+ */
+
+//#define SSCS_CUSTOM_MALLOC /* comment out to use the system specific malloc & free */
+
+#ifdef SSCS_CUSTOM_MALLOC
+	#include "protected_malloc.h"
+#else
+	#define cmalloc(size) calloc(1,size) 
+	#define cfree(ptr) free(ptr) 
+	#define cmalloc_init() puts("") 
 #endif
+
+#endif /* SSC_SETTINGSHFSRV */

--- a/server/makefile
+++ b/server/makefile
@@ -18,19 +18,32 @@
 # *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # */
 
-SSCServer: main.o sscsrvfunc.o base64.o serialization.o hashing.o
-	gcc -o SSCServer base64.o sscsrvfunc.o main.o serialization.o hashing.o `mysql_config --cflags --libs` -lcrypto -lssl -Wall -Wextra -O
+#Security flags for compiling
+security_flags = -D_FORTIFY_SOURCE=2 -fstack-protector-all -fstack-check -pie -fPIE -Wall -Wextra -Wformat -Wformat-security -O3 -g -Wl,-z,relro,-z,now 
+
+SSCServer: main.o sscsrvfunc.o base64.o serialization.o hashing.o protected_malloc.o
+	gcc $(security_flags) -o SSCServer base64.o sscsrvfunc.o main.o serialization.o hashing.o protected_malloc.o `mysql_config --cflags --libs` -lcrypto -lssl
 	rm -f *.o
 main.o: secure_chat_server.c
-	gcc -o main.o -c secure_chat_server.c `mysql_config --cflags --libs` -lcrypto -lssl -Wall -Wextra -O -static 
+	gcc $(security_flags) -o main.o -c secure_chat_server.c `mysql_config --cflags --libs` -lcrypto -lssl
+
 sscsrvfunc.o: headers/sscsrvfunc.h headers/sscsrvfunc.c
-	gcc -o sscsrvfunc.o -c headers/sscsrvfunc.c `mysql_config --cflags --libs` -lssl -lcrypto -Wall -Wextra -O -static 
+	gcc $(security_flags) -o sscsrvfunc.o -c headers/sscsrvfunc.c `mysql_config --cflags --libs` -lssl -lcrypto
+
 serialization.o: headers/serialization.c headers/serialization.h
-	gcc -o serialization.o -c headers/serialization.c -Wall -Wextra -O -static 
+	gcc $(security_flags) -o serialization.o -c headers/serialization.c
+
 base64.o: headers/base64.h headers/base64.c
-	gcc -o base64.o -c headers/base64.c -Wall -Wextra -O -static 
+	gcc $(security_flags) -o base64.o -c headers/base64.c
+
+
 hashing.o: headers/hashing.c headers/hashing.h
-	gcc -o hashing.o -c headers/hashing.c -Wall -Wextra -O -static -lcrypto 
+	gcc $(security_flags) -o hashing.o -c headers/hashing.c -lcrypto
+
+
+protected_malloc.o: headers/protected_malloc.c headers/protected_malloc.h
+	gcc $(security_flags) -o protected_malloc.o -c headers/protected_malloc.c
+
 clean:
 	rm -f *.o SSCServer* temp 
 gitprep: clean


### PR DESCRIPTION
Add tons of gcc flags(-FORTIFY_SOURCE=2,  -fstack-protector-all & more)(in makefile) for securing stack & optional custom malloc that adds a guard page to every allocated buffer to protect against heap overflows -> 4KB overhead per alloc. To use system malloc&free comment out SSCS_CUSTOM_MALLOC in headers/settings.h.